### PR TITLE
Sharding enhancement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6931,14 +6931,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -6974,6 +6966,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chai": "^4.1.2",
     "commander": "^2.11.0",
     "foglet-signaling-server": "^0.3.1",
+    "glob": "^7.1.2",
     "istanbul-instrumenter-loader": "^3.0.0",
     "karma": "^1.7.1",
     "karma-chai": "^0.1.0",

--- a/src/karma/karma-runner.js
+++ b/src/karma/karma-runner.js
@@ -31,7 +31,7 @@ class KarmaRunner extends EventEmitter {
   constructor (jsonConfig, callback) {
     super()
     this._jsonConfig = jsonConfig
-    this._karmaConfig = getConfig(jsonConfig.browsers, jsonConfig.exclude, jsonConfig.timeout, jsonConfig.lint)
+    this._karmaConfig = getConfig(jsonConfig.browsers, jsonConfig.exclude, jsonConfig.timeout, jsonConfig.lint, jsonConfig.sharding)
     this._server = new Server(this._karmaConfig, exitCode => {
       callback(exitCode)
       stopper.stop({ port: this._karmaConfig.port })

--- a/src/read-config.js
+++ b/src/read-config.js
@@ -28,6 +28,7 @@ const path = require('path')
 
 const DEFAULT_CONFIG = {
   browsers: [],
+  sharding: false,
   exclude: [],
   timeout: 5000,
   lint: true,

--- a/src/utils/clear.js
+++ b/src/utils/clear.js
@@ -1,0 +1,16 @@
+/**
+ * Clear all foglets to undefined
+ * @param  {Foglet[]}  peers - Foglet peers to connect with the centeral peer.
+ * @return {Promise} A Promise fullfilled when all peers are cleared, means equal to undefined
+ */
+const clearFoglets = (peers) => {
+  return new Promise((resolve, reject) => {
+    try {
+      resolve(peers.map(p => undefined))
+    } catch (e) {
+      reject(e)
+    }
+  })
+}
+
+module.exports = { clearFoglets };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -24,6 +24,7 @@ SOFTWARE.
 'use strict'
 
 const { overlayConnect, pathConnect, starConnect } = require('./connection.js')
+const { clearFoglets } = require('./clear.js')
 
 /**
  * Perform a Mocha/Jasmine test with the `done` callback, but only terminate the
@@ -43,6 +44,7 @@ const doneAfter = (limit, test) => {
 }
 
 module.exports = {
+  clear: clearFoglets,
   connect: {
     path: pathConnect,
     star: starConnect,

--- a/tests/karma/read-config-test.js
+++ b/tests/karma/read-config-test.js
@@ -32,6 +32,7 @@ describe('Configuration reader', () => {
     const config = readConfig({})
     const expected = {
       browsers: [],
+      sharding: false,
       exclude: [],
       timeout: 5000,
       lint: true,
@@ -54,6 +55,7 @@ describe('Configuration reader', () => {
       browsers: [
         'Firefox'
       ],
+      sharding: false,
       exclude: [
         'tests/karma/*.js',
         'tests/utils/*.js'

--- a/tests/karma/sharding-test.js
+++ b/tests/karma/sharding-test.js
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2017 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+'use strict'
+
+const readConfig = require('../../src/read-config.js')
+const KarmaConfig = require('../../src/karma/karma-config.js')
+jest.setTimeout(30000)
+
+describe('Sharding tests', () => {
+	it('should be the same browsers when sharding=false', () => {
+    const config = readConfig({ 'foglet-scripts': { browsers: ['Firefox', 'Chrome'], sharding: false }})
+    expect(config.browsers).toEqual(['Firefox', 'Chrome']);
+  })
+  it('should create an array of browsers fitting the number of file tests, all equal to the first browser', () => {
+    const config = readConfig({ 'foglet-scripts': { browsers: ['Firefox', 'Chrome'], sharding: true }});
+    expect(config.browsers.length).toBeGreaterThan(1);
+		expect(config.browsers[0]).toEqual('Firefox');
+		const karmaConf = KarmaConfig(config.browsers, config.exclude, config.timeout, config.lint, config.sharding);
+		expect(karmaConf.browsers).not.toContain('Chrome');
+  });
+})

--- a/tests/utils/clear-test.js
+++ b/tests/utils/clear-test.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const { clear } = require('../../src/utils/utils.js')
+
+describe('clear', () => {
+  it('should clear all value', (done) => {
+		clear([1, 2, 3]).then((tab) => {
+			expect(tab).toEqual([undefined, undefined, undefined]);
+			done();
+		});
+	});
+})


### PR DESCRIPTION
By passing option `sharding: true` you will now shard all your tests into one browser.
According to the browser you provided.
Example: 
```json
{
 "browsers": [ "Firefox", "Chrome" ],
 "sharding": true
}
``` 
If you have 15 test files in the folder tests/ you will have 15 "Firefox" loaded. 
Each test in one  browser.
What do you think about this PR ? :-)